### PR TITLE
Add index view to Issue

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    trailer_vote-fixtures (0.1.0)
+    trailer_vote-fixtures (1.2.0)
 
 PLATFORMS
   ruby
@@ -44,8 +44,8 @@ DEPENDENCIES
   oj (~> 3.6)
   rake (~> 10.0)
   simplecov (~> 0.16)
-  trailer_vote-fixtures
+  trailer_vote-fixtures (~> 1.2)
   trailer_vote-media_types!
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/ruby/lib/trailer_vote/media_types/issue.rb
+++ b/ruby/lib/trailer_vote/media_types/issue.rb
@@ -9,6 +9,16 @@ module TrailerVote
       media_type 'issue', defaults: { suffix: :json, version: 1 }
 
       validations do
+        index_scheme = ::MediaTypes::Scheme.new do
+          attribute :issues do
+            collection :_index, allow_empty: true do
+              attribute :href, Types::HttpUrl
+              not_strict
+            end
+
+            not_strict
+          end
+        end
 
         version 1 do
           version_1_base = ::MediaTypes::Scheme.new do
@@ -35,11 +45,16 @@ module TrailerVote
               merge version_1_base
             end
           end
+
+          view 'index' do
+            merge index_scheme
+          end
         end
       end
 
       registrations :issue do
         view 'create', :create_issue
+        view 'index', :issue_urls
 
         versions 1
       end

--- a/ruby/test/trailer_vote/media_types/issue_test.rb
+++ b/ruby/test/trailer_vote/media_types/issue_test.rb
@@ -19,9 +19,9 @@ module TrailerVote
           end
 
           formatted_mime_type 'application/vnd.trailervote.issue.v%<version>s.%<view>s+json' do
-
             version 1 do
               view 'create', symbol: :create_issue_v1_json, synonyms: []
+              view 'index', symbol: :issue_urls_v1_json, synonyms: []
             end
           end
         end

--- a/ruby/trailer_vote-media_types.gemspec
+++ b/ruby/trailer_vote-media_types.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'oj', '~> 3.6'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'simplecov', '~> 0.16'
-  spec.add_development_dependency 'trailer_vote-fixtures'
+  spec.add_development_dependency 'trailer_vote-fixtures', '~> 1.2'
 end


### PR DESCRIPTION
Adds the `index` view to the Issue media type, as required by the open/unresolved issue listing for the TrailerVote API