### PR TITLE
Allow push campaign collection to be empty

### DIFF
--- a/ruby/lib/trailer_vote/media_types/push_manifest.rb
+++ b/ruby/lib/trailer_vote/media_types/push_manifest.rb
@@ -17,7 +17,7 @@ module TrailerVote
       validations do
         version 1 do
           attribute :push_manifest do
-            collection :campaigns do
+            collection :campaigns, allow_empty: true do
               link :audio_fragment
               link :campaign
             end


### PR DESCRIPTION
Fixes https://github.com/TrailerVote/trailervote-api/issues/489